### PR TITLE
override getDataStore()

### DIFF
--- a/src/test/groovy/joe/TestSpec.groovy
+++ b/src/test/groovy/joe/TestSpec.groovy
@@ -1,6 +1,8 @@
 package joe
 
 import grails.testing.gorm.DomainUnitTest
+import org.grails.datastore.mapping.core.AbstractDatastore
+import org.grails.datastore.mapping.simple.SimpleMapDatastore
 import spock.lang.Specification
 
 class TestSpec extends Specification implements DomainUnitTest<Test> {
@@ -13,9 +15,14 @@ class TestSpec extends Specification implements DomainUnitTest<Test> {
 
     void "test save"() {
         setup:
-        new Test(name: 'myName').save()
+        new Test(name: 'myName').save(flush: true)
 
         expect:
         Test.count() > 0
     }
+
+	@Override
+	AbstractDatastore getDataStore() {
+		return new SimpleMapDatastore(['myDataSource'], Test)
+	}
 }


### PR DESCRIPTION
i investigated a little further to check how SimpleMapDatastore is initialized. Found here https://github.com/grails/grails-testing-support/blob/573ecae5313843271ed8aa651025db45d68613da/grails-gorm-testing-support/src/main/groovy/org/grails/testing/gorm/spock/DataTestSetupSpecInterceptor.groovy#L49 that for the class is always initialized to use default connection. 
So as workaround, I override getDataStore() of DataTest class to force the spec to use different datastore